### PR TITLE
Added simple rez configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -465,3 +465,6 @@ set (CPACK_COMPONENT_DEVELOPER_DESCRIPTION "Include files")
 set (CPACK_COMPONENT_DOCUMENTATION_DESCRIPTION "OpenImageIO documentation")
 set (CPACK_COMPONENT_DEVELOPER_DEPENDS user)
 include (CPack)
+
+#REZ build
+include(RezBuild)

--- a/package.py
+++ b/package.py
@@ -1,0 +1,32 @@
+name = "oiio"
+
+version = "3.5.82_spiArn"
+
+authors = [
+    "lg"
+]
+
+
+description = \
+"""
+The primary target audience for OIIO is VFX studios and developers of tools such 
+as renderers, compositors, viewers, and other image-related software you'd find 
+in a production pipeline.
+"""
+
+tools = [
+    'iconvert',
+    'idiff',
+    'igrep',
+    'iinfo',
+    'maketx',
+    'oiiotool',
+]
+
+variants = [
+    ['platform-linux'],
+]
+
+def commands():
+    env.PYTHONPATH.append('{root}/lib/python2.7/site-packages')
+    env.PATH.append('{root}/bin')


### PR DESCRIPTION
## Description
For inclusion in a rez environment. Be sure to install rez on your machine.

*Added a rez package definition. It defines the packages version, authors, description, tools, variants, and environment configuration.
* Added rez build to CMakelists.

To build using rez:
`rez build -i -b cmake`  
The -b specifies the make system. Rez is a little confused by the Makefile and CMakeLists in the same directory.

The rez build command creates a directory for each variant encoded in the variants list. The current build commands are creating them in a 'build/linux64' directory. The new rez directory would be 'build/platform-linux'. The entire contents of the build directory is being deployed into the rez local area '${REZ_PACKAGES_PATH}/oiio/{REZ_OIIO_VERSION}/platform-linux/'

The rez package.py commands function is encoding the PYTHONPATH and PATH environment variables to point to the appropriate files. 

Examples of resolving a oiio rez environment.
rez env oiio -- oiiotool
rez env oiio -- maketx

I know I only added a couple lines to the CMakelists file. Someone may want to take another look at this and see if you can make the integration smoother. For a naive implementation, I believe this works.

## Tests

I have not changed source code. I do not know how to create a unittest for the changes to the build step. 

How do we make the CMakeLists change more fault tolerant for systems without rez?


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [ x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x ] My code follows the prevailing code style of this project.

